### PR TITLE
Support iOS 11+

### DIFF
--- a/Sources/DeepLook/API/DeepLook.swift
+++ b/Sources/DeepLook/API/DeepLook.swift
@@ -5,8 +5,10 @@ import UIKit
 import Vision
 
 /// Reference to `LKRecognition.default` for quick bootstrapping and examples.
+@available (iOS 13.0, *)
 public let DeepLook = LKDeepLook.default
 
+@available (iOS 13.0, *)
 public class LKDeepLook {
 
   /// shared instance.

--- a/Sources/DeepLook/API/Detecotor.swift
+++ b/Sources/DeepLook/API/Detecotor.swift
@@ -4,8 +4,10 @@ import Foundation
 import UIKit
 
 /// Reference to `LKDetector.default` for quick bootstrapping and examples.
+@available(iOS 13.0, *)
 public let Detector = LKDetector.default
 
+@available (iOS 13.0, *)
 public class LKDetector {
 
   // shared instance
@@ -92,7 +94,7 @@ public class LKDetector {
   }
 }
 
-
+@available (iOS 13.0, *)
 private extension LKDetector {
 
   func analyze(

--- a/Sources/DeepLook/API/ImageProcessor.swift
+++ b/Sources/DeepLook/API/ImageProcessor.swift
@@ -4,8 +4,10 @@ import Foundation
 import UIKit
 
 /// Reference to `LKImageProcessor.default` for quick bootstrapping and examples.
+@available (iOS 13.0, *)
 public let ImageProcessor = LKImageProcessor.default
 
+@available (iOS 13.0, *)
 public class LKImageProcessor {
 
   // shared instance

--- a/Sources/DeepLook/API/Recognition.swift
+++ b/Sources/DeepLook/API/Recognition.swift
@@ -4,8 +4,10 @@ import Foundation
 import UIKit
 
 /// Reference to `LKRecognition.default` for quick bootstrapping and examples.
+@available (iOS 13.0, *)
 public let Recognition = LKRecognition.default
 
+@available (iOS 13.0, *)
 public class LKRecognition {
   
   // shared instance
@@ -252,6 +254,7 @@ public class LKRecognition {
   }
 }
 
+@available (iOS 13.0, *)
 private extension LKRecognition {
   func groupFaces(faces: [Face], clusterOptions: ClusterOptions) -> [[Face]] {
     switch clusterOptions.clusterType {

--- a/Sources/DeepLook/Enum/TaskResult.swift
+++ b/Sources/DeepLook/Enum/TaskResult.swift
@@ -1,6 +1,7 @@
 //  Created by Amir Lahav on 30/07/2022.
 //  Copyright © 2019 la-labs. All rights reserved.
 
+@available (iOS 13.0, *)
 public enum TaskResult<Success: Sendable>: Sendable {
   case success(Success)
   case failure(Error)

--- a/Sources/DeepLook/Extention/Operator.swift
+++ b/Sources/DeepLook/Extention/Operator.swift
@@ -16,6 +16,7 @@ func |> <U, T> (x: U, f: (U) throws -> T) rethrows -> T {
     return try f(x)
 }
 
+@available (iOS 13.0, *)
 func |> <U, T> (x: U, f: (U) async throws -> T) async rethrows -> T {
     return try await f(x)
 }

--- a/Sources/DeepLook/ML/Actions.swift
+++ b/Sources/DeepLook/ML/Actions.swift
@@ -14,8 +14,10 @@ typealias JobPipeline = (ProcessInput) throws -> ProcessOutput
 typealias CustomFilter<T> = (ProcessInput) throws -> T
 
 /// Reference to `LKActions.default` for quick bootstrapping and examples.
+@available (iOS 13.0, *)
 public let Actions = LKActions.default
 
+@available (iOS 13.0, *)
 public class LKActions {
   
   /// Models
@@ -520,6 +522,7 @@ public class LKActions {
   }
 }
 
+@available (iOS 13.0, *)
 private extension LKActions {
 
   func boundingBoxToRects(observation: [VNFaceObservation]) -> [CGRect] {

--- a/Sources/DeepLook/Manager/ActionType.swift
+++ b/Sources/DeepLook/Manager/ActionType.swift
@@ -12,6 +12,7 @@ public extension ActionType {
   }
 }
 
+@available (iOS 13.0, *)
 public extension ActionType {
   static var faceLocation: ActionType<ProcessInput> {
     .init(process: Actions.faceLocation)

--- a/Sources/DeepLook/Manager/Processor.swift
+++ b/Sources/DeepLook/Manager/Processor.swift
@@ -10,6 +10,7 @@ typealias AsyncMultiplePipe<Input,Output> = ([Input]) async throws -> [Output]
 typealias GenericStackProcessor<Input,Output> = (Stack<[Input]>) async throws -> [Output]
 typealias StackProcessor = (Stack<[ProcessAsset]>) throws -> [ProcessAsset]
 
+@available (iOS 13.0, *)
 class Processor {    
   static func singleInputProcessor<Input, Output>(
     element: Input,

--- a/Sources/DeepLook/Manager/Vision.swift
+++ b/Sources/DeepLook/Manager/Vision.swift
@@ -8,6 +8,7 @@ class Vision {
     static let assetService = AssetService()
 }
 
+@available (iOS 13.0, *)
 extension Vision {
 
   static func detect(objects stack: Stack<[ProcessInput]>,

--- a/Sources/DeepLook/Services/ImageFetcherService.swift
+++ b/Sources/DeepLook/Services/ImageFetcherService.swift
@@ -13,7 +13,7 @@ import AppKit
 import UIKit
 #endif
 
-
+@available (iOS 13.0, *)
 public class ImageFetcherService {
     
     private let imgManager = PHImageManager.default()


### PR DESCRIPTION
Functions from DeepLook are still not working on iOS 11/12, but now projects will be available to build on older iOS and use functions only for users on iOS 13+.

Is it possible to rebuild DeepLookModels.xcframework for iOS 11? My project still crashes on start on iOS 11 because only of this framework.